### PR TITLE
Modified illuminate config usage

### DIFF
--- a/src/Noherczeg/Breadcrumb/Config.php
+++ b/src/Noherczeg/Breadcrumb/Config.php
@@ -43,7 +43,11 @@ class Config
     {
         if (!is_string($key)) {
             throw new \InvalidArgumentException("Invalid argument provided, string required!");
-        } elseif(method_exists('\Illuminate\Config\Repository', 'get') &&  \Config::get('breadcrumb::' . $key, false) !== false) {
+        } elseif(
+            method_exists('\Illuminate\Config\Repository', 'get') &&
+            method_exists('\Config', 'get') &&
+            \Config::get('breadcrumb::' . $key, false) !== false
+        ) {
             return \Config::get('breadcrumb::' . $key, false);
         } elseif (!array_key_exists($key, $this->configs)) {
             throw new \OutOfRangeException("There is no " . $key . " key in the Configurations!");


### PR DESCRIPTION
Modified illuminate config usage to only run where `\Config` is actually defined, ( Due to including `illuminate/config` package but not implementing laravel's facades )
